### PR TITLE
Pass extra data to xprofile_cover_image_uploaded hook

### DIFF
--- a/files.php
+++ b/files.php
@@ -579,7 +579,10 @@ function vip_handle_cover_image_upload( $_, $args, $needs_reset, $object_data ) 
 
 	do_action(
 		$object_data['component'] . '_cover_image_uploaded',
-		(int) $args['item_id']
+		(int) $args['item_id'],
+		basename( $result['url'] ),
+		$result['url'],
+		1
 	);
 
 	$retval = array(


### PR DESCRIPTION
A fatal error was happening:

<details>
<summary>Partial stacktrace</summary>

PHP message: PHP Fatal error: Uncaught ArgumentCountError: Too few arguments to function bb_save_profile_group_cover_options_on_upload_custom_cover(), 1 passed in /var/www/wp-includes/class-wp-hook.php on line 324 and exactly 4 expected in /var/www/wp-content/plugins/buddyboss-platform/bp-core/bp-core-filters.php:2083

Stack trace:
#0 /var/www/wp-includes/class-wp-hook.php(324): bb_save_profile_group_cover_options_on_upload_custom_cover(11)
#1 /var/www/wp-includes/class-wp-hook.php(348): WP_Hook->apply_filters(NULL, Array)
#2 /var/www/wp-includes/plugin.php(517): WP_Hook->do_action(Array)
#3 /var/www/wp-content/plugins/buddypress-vip-go/files.php(580): do_action('xprofile_cover_...', 11)
#4 /var/www/wp-includes/class-wp-hook.php(324): vip_handle_cover_image_upload(Array, Array, Array, Array)
#5 /var/www/wp-includes/plugin.php(205): WP_Hook->apply_filters(Array, Array)
#6 /var/www/wp-content/plugins/buddyboss-platform/bp-core/bp-core-attachments.php(1558): apply_filters('bp_attachments_...', Array, Array, Array, Array)

</details>

The `do_action()` call inside `vip_handle_cover_image_upload()` wasn't sending over enough pieces of data.