### PR TITLE
Add support for group video uploads and override temp directory

### DIFF
--- a/files.php
+++ b/files.php
@@ -812,6 +812,12 @@ function vipbp_handle_temp_directory_removal( $directory ) {
 		return false;
 	}
 
+	// Handle vip:// protocol URLs
+	if ( 0 === strpos( $directory, 'vip://' ) ) {
+		// Convert vip:// URL to a regular path
+		$directory = str_replace( 'vip://', '', $directory );
+	}
+
 	// Get the system temp directory
 	$tmp_dir = get_temp_dir();
 	
@@ -852,5 +858,6 @@ function vipbp_handle_temp_directory_removal( $directory ) {
 		}
 	}
 
-	return false;
+	// Return an empty array to prevent the reset() error
+	return array();
 }

--- a/files.php
+++ b/files.php
@@ -45,7 +45,21 @@ add_action(
 		/*
 		* Tweaks for handling temporary directory cleanup.
 		*/
-		add_filter( 'bp_core_pre_remove_temp_directory', 'vipbp_handle_temp_directory_removal', 10, 1 );
+		add_filter( 'bp_core_remove_temp_directory', 'vipbp_handle_temp_directory_removal', 10, 1 );
+
+		/*
+		* Video upload tracking hooks
+		*/
+		add_action( 'bb_before_video_upload_handler', 'vipbp_log_video_upload_start' );
+		add_action( 'bb_after_video_upload_handler', 'vipbp_log_video_upload_complete' );
+		add_action( 'bb_video_upload', 'vipbp_log_video_upload_attachment', 10, 1 );
+		add_action( 'bb_before_video_preview_image_by_js', 'vipbp_log_preview_image_start' );
+		add_action( 'bb_after_video_preview_image_by_js', 'vipbp_log_preview_image_complete' );
+		add_action( 'bp_video_before_background_process_create', 'vipbp_log_thumbnail_generation_start', 10, 1 );
+		add_action( 'bp_video_after_background_process_create', 'vipbp_log_thumbnail_generation_complete', 10, 1 );
+		add_action( 'bb_video_after_preview_generate', 'vipbp_log_preview_generation_complete' );
+		add_action( 'bp_video_after_background_create_thumbnail', 'vipbp_log_thumbnail_creation_complete', 10, 1 );
+		add_action( 'bb_try_after_video_background_create_thumbnail', 'vipbp_log_thumbnail_creation_attempt_complete', 10, 1 );
 	} 
 );
 
@@ -805,17 +819,28 @@ function vipbp_delete_cover_image( $_, $args ) {
  * 3. Uses WordPress's file system functions where possible
  *
  * @param string $directory Directory to remove.
- * @return false Shortcircuits bp_core_remove_temp_directory().
+ * @return array Empty array to prevent reset() error.
  */
 function vipbp_handle_temp_directory_removal( $directory ) {
+	error_log( sprintf(
+		'[VIPBP Video] Temp directory removal handler called. Directory: %s',
+		$directory
+	) );
+
 	if ( empty( $directory ) ) {
-		return false;
+		error_log( '[VIPBP Video] Empty directory provided to removal handler' );
+		return array();
 	}
 
 	// Handle vip:// protocol URLs
 	if ( 0 === strpos( $directory, 'vip://' ) ) {
-		// Convert vip:// URL to a regular path
+		$original_directory = $directory;
 		$directory = str_replace( 'vip://', '', $directory );
+		error_log( sprintf(
+			'[VIPBP Video] Converted vip:// URL. Original: %s, New: %s',
+			$original_directory,
+			$directory
+		) );
 	}
 
 	// Get the system temp directory
@@ -823,6 +848,11 @@ function vipbp_handle_temp_directory_removal( $directory ) {
 	
 	// If the directory is in /tmp, we can use normal file operations
 	if ( 0 === strpos( $directory, $tmp_dir ) ) {
+		error_log( sprintf(
+			'[VIPBP Video] Directory is in /tmp. Using normal file operations. Path: %s',
+			$directory
+		) );
+		
 		// Use WordPress's file system functions
 		global $wp_filesystem;
 		if ( ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
@@ -831,7 +861,13 @@ function vipbp_handle_temp_directory_removal( $directory ) {
 		}
 
 		if ( is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
-			$wp_filesystem->delete( $directory, true );
+			$result = $wp_filesystem->delete( $directory, true );
+			error_log( sprintf(
+				'[VIPBP Video] WP_Filesystem delete result: %s',
+				$result ? 'success' : 'failed'
+			) );
+		} else {
+			error_log( '[VIPBP Video] WP_Filesystem not available for /tmp operation' );
 		}
 	} else {
 		// For files in the VIP File System, we need to handle them differently
@@ -839,10 +875,21 @@ function vipbp_handle_temp_directory_removal( $directory ) {
 		$upload_dir = wp_upload_dir();
 		$basedir = $upload_dir['basedir'];
 		
+		error_log( sprintf(
+			'[VIPBP Video] Directory is in VIP File System. Basedir: %s, Directory: %s',
+			$basedir,
+			$directory
+		) );
+		
 		// If the directory is within uploads, we need to handle it file by file
 		if ( 0 === strpos( $directory, $basedir ) ) {
 			// Get the relative path from uploads
 			$relative_path = substr( $directory, strlen( $basedir ) );
+			
+			error_log( sprintf(
+				'[VIPBP Video] Directory is within uploads. Relative path: %s',
+				$relative_path
+			) );
 			
 			// Use WordPress's file system functions to delete files
 			global $wp_filesystem;
@@ -852,12 +899,118 @@ function vipbp_handle_temp_directory_removal( $directory ) {
 			}
 
 			if ( is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
-				// Delete the directory itself
-				$wp_filesystem->delete( $directory, true );
+				$result = $wp_filesystem->delete( $directory, true );
+				error_log( sprintf(
+					'[VIPBP Video] WP_Filesystem delete result for VIP File System: %s',
+					$result ? 'success' : 'failed'
+				) );
+			} else {
+				error_log( '[VIPBP Video] WP_Filesystem not available for VIP File System operation' );
 			}
+		} else {
+			error_log( sprintf(
+				'[VIPBP Video] Directory is not within uploads. Directory: %s',
+				$directory
+			) );
 		}
 	}
 
-	// Return an empty array to prevent the reset() error
+	error_log( '[VIPBP Video] Temp directory removal handler completed' );
 	return array();
+}
+
+/**
+ * Log the start of a video upload operation.
+ */
+function vipbp_log_video_upload_start() {
+	error_log( '[VIPBP Video] Starting video upload' );
+}
+
+/**
+ * Log the completion of a video upload operation.
+ */
+function vipbp_log_video_upload_complete() {
+	error_log( '[VIPBP Video] Completed video upload' );
+}
+
+/**
+ * Log video upload attachment details.
+ *
+ * @param mixed $attachment The attachment object.
+ */
+function vipbp_log_video_upload_attachment( $attachment ) {
+	error_log( sprintf(
+		'[VIPBP Video] Video upload attachment created. ID: %d, Title: %s',
+		$attachment->ID,
+		$attachment->post_title
+	) );
+}
+
+/**
+ * Log the start of a preview image operation.
+ */
+function vipbp_log_preview_image_start() {
+	error_log( '[VIPBP Video] Starting preview image processing' );
+}
+
+/**
+ * Log the completion of a preview image operation.
+ */
+function vipbp_log_preview_image_complete() {
+	error_log( '[VIPBP Video] Completed preview image processing' );
+}
+
+/**
+ * Log the start of thumbnail generation.
+ *
+ * @param BP_Video $video The video object.
+ */
+function vipbp_log_thumbnail_generation_start( $video ) {
+	error_log( sprintf(
+		'[VIPBP Video] Starting thumbnail generation for video ID: %d',
+		$video->id
+	) );
+}
+
+/**
+ * Log the completion of thumbnail generation.
+ *
+ * @param BP_Video $video The video object.
+ */
+function vipbp_log_thumbnail_generation_complete( $video ) {
+	error_log( sprintf(
+		'[VIPBP Video] Completed thumbnail generation for video ID: %d',
+		$video->id
+	) );
+}
+
+/**
+ * Log the completion of preview generation.
+ */
+function vipbp_log_preview_generation_complete() {
+	error_log( '[VIPBP Video] Completed preview generation' );
+}
+
+/**
+ * Log the completion of thumbnail creation.
+ *
+ * @param BP_Video $video The video object.
+ */
+function vipbp_log_thumbnail_creation_complete( $video ) {
+	error_log( sprintf(
+		'[VIPBP Video] Completed thumbnail creation for video ID: %d',
+		$video->id
+	) );
+}
+
+/**
+ * Log the completion of thumbnail creation attempt.
+ *
+ * @param BP_Video $video The video object.
+ */
+function vipbp_log_thumbnail_creation_attempt_complete( $video ) {
+	error_log( sprintf(
+		'[VIPBP Video] Completed thumbnail creation attempt for video ID: %d',
+		$video->id
+	) );
 }

--- a/files.php
+++ b/files.php
@@ -60,6 +60,11 @@ add_action(
 		add_action( 'bb_video_after_preview_generate', 'vipbp_log_preview_generation_complete' );
 		add_action( 'bp_video_after_background_create_thumbnail', 'vipbp_log_thumbnail_creation_complete', 10, 1 );
 		add_action( 'bb_try_after_video_background_create_thumbnail', 'vipbp_log_thumbnail_creation_attempt_complete', 10, 1 );
+
+		/**
+		 * Tweaks for uploading group videos.
+		 */
+		add_filter( 'bp_core_pre_remove_temp_directory', 'vipbp_override_remove_temp_directory', 10, 3 );
 	} 
 );
 
@@ -1013,4 +1018,25 @@ function vipbp_log_thumbnail_creation_attempt_complete( $video ) {
 		'[VIPBP Video] Completed thumbnail creation attempt for video ID: %d',
 		$video->id
 	) );
+}
+
+/**
+ * Override bp_core_remove_temp_directory on VIP to use WP_Filesystem.
+ *
+ * @param bool   $override   Whether to override the default behavior.
+ * @param string $directory  The directory to remove.
+ * @param string $image_name The name of the image file to delete.
+ *
+ * @return bool True if overridden on VIP, otherwise false.
+ */
+function vipbp_override_remove_temp_directory( $override, $directory, $image_name ) {
+	$file_path = trailingslashit( $directory ) . $image_name . '.jpg';
+	if ( file_exists( $file_path ) ) {
+		// Skip default directory deletion logic.
+		wp_delete_file( $file_path );
+		return true;
+	} else {
+		// Continue with default behavior.
+		return false;
+	}
 }


### PR DESCRIPTION
## Issue

When attempting to upload a **video** into a **group**, the upload process gets stuck and the video fails to upload.

This issue was caused during the handling of the temporary video file. The **BuddyBoss** plugin was using **non-VIP-compatible functions** such as `is_dir()` and `scandir()` to delete the temporary file. Additionally, no hooks were provided to override this behavior, making it difficult to patch cleanly.

## Fix

A custom **hook** was introduced in a site repo to allow overriding this behavior. Without that patch, the code will not run.

The patch file:

```diff
diff --git a/plugins/buddyboss-platform/bp-core/bp-core-functions.php b/plugins/buddyboss-platform/bp-core/bp-core-functions.php
index 4b7d292..98c3b0f 100644
--- a/plugins/buddyboss-platform/bp-core/bp-core-functions.php
+++ b/plugins/buddyboss-platform/bp-core/bp-core-functions.php
@@ -5420,10 +5420,19 @@ function bp_core_regenerate_attachment_thumbnails( $attachment_id ) {
  * Function which remove the temporary created directory.
  *
  * @param string $directory Directory to remove.
+ * @param string $image_name Name of the image file to remove (optional).
  *
  * @since BuddyBoss 1.7.0
  */
-function bp_core_remove_temp_directory( $directory = '' ) {
+function bp_core_remove_temp_directory( $directory = '', $image_name = '' ) {
+	/**
+	 * Allow plugins to override temporary directory removal.
+	 * Returning true from this filter will skip the default removal logic.
+	 */
+	if ( apply_filters( 'bp_core_pre_remove_temp_directory', false, $directory, $image_name ) ) {
+		return;
+	}
+
 	if ( is_dir( $directory ) ) {
 		$objects = scandir( $directory );
 		foreach ( $objects as $object ) {
diff --git a/plugins/buddyboss-platform/bp-video/bp-video-functions.php b/plugins/buddyboss-platform/bp-video/bp-video-functions.php
index 1c72f8a..34ac30d 100644
--- a/plugins/buddyboss-platform/bp-video/bp-video-functions.php
+++ b/plugins/buddyboss-platform/bp-video/bp-video-functions.php
@@ -879,7 +879,7 @@ function bp_video_preview_image_by_js( $video ) {
 	// Deregister image sizes.
 	bb_video_deregister_image_sizes();

-	bp_core_remove_temp_directory( $upload_dir );
+	bp_core_remove_temp_directory( $upload_dir, $image_name );
```

This PR implements the hook and provides a **VIP-compatible** way to delete the temporary video file, ensuring the upload process completes successfully.