### PR TITLE
fix: Add DOING_AJAX check for A8C_Files initialization

### DIFF
--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
 add_action(
 	'bp_loaded',
 	function () {
-		if ( ! class_exists( 'A8C_Files' ) || ! defined( 'FILES_CLIENT_SITE_ID' ) || ! defined( 'FILES_ACCESS_TOKEN' ) ) {
+		if ( ! defined( 'DOING_AJAX' ) || ! class_exists( 'A8C_Files' ) || ! defined( 'FILES_CLIENT_SITE_ID' ) || ! defined( 'FILES_ACCESS_TOKEN' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
This allows file-handling amendments to work during Ajax requests, too.

In the case of BuddyBoss, where a default cover image can be uploaded, the ability to correctly remove the uploaded image wasn't working before this fix was applied.