### PR TITLE
fix: Improve loading condition logic

### DIFF
--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -25,10 +25,12 @@ defined( 'ABSPATH' ) || exit;
 add_action(
 	'bp_loaded',
 	function () {
-		if ( ! defined( 'DOING_AJAX' ) || ! class_exists( 'A8C_Files' ) || ! defined( 'FILES_CLIENT_SITE_ID' ) || ! defined( 'FILES_ACCESS_TOKEN' ) ) {
-			return;
-		}
+		$is_ajax       = defined( 'DOING_AJAX' ) && DOING_AJAX;
+		$vip_available = class_exists( 'A8C_Files' ) && defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' );
 
-		require_once __DIR__ . '/files.php';
+		// Load files.php if it's an AJAX request OR if VIP environment is available.
+		if ( $is_ajax || $vip_available ) {
+			require_once __DIR__ . '/files.php';
+		}
 	} 
 );

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -25,12 +25,10 @@ defined( 'ABSPATH' ) || exit;
 add_action(
 	'bp_loaded',
 	function () {
-		$is_ajax       = defined( 'DOING_AJAX' ) && DOING_AJAX;
 		$vip_available = class_exists( 'A8C_Files' ) && defined( 'FILES_CLIENT_SITE_ID' ) && defined( 'FILES_ACCESS_TOKEN' );
 
-		// Load files.php if it's an AJAX request OR if VIP environment is available.
-		if ( $is_ajax || $vip_available ) {
+		if ( $vip_available ) {
 			require_once __DIR__ . '/files.php';
 		}
-	} 
+	}
 );


### PR DESCRIPTION
Fixes #22.

In https://github.com/Automattic/BuddyPress-VIP-Go/pull/18, the undefined DOING_AJAX check was added, since none of the other negativised conditions are truthy in an Ajax request, so the filters weren't loading, and the BuddyBoss delete default cover image feature wasn't working.

However, this meant that as per https://github.com/Automattic/BuddyPress-VIP-Go/issues/22, the logic was running incorrectly - if the constant isn't defined (as per regular non-Ajax requests), then the function was hitting the `return`.

By refactoring this to remove the double-negatives, we can simplify the logic - if the Ajax constant is true, or the conditions for us working with the VIP Filesystem are true, then apply the filters.