### PR TITLE
Add wp-env configuration for local development

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -1,0 +1,20 @@
+{
+  "plugins": [
+    "."
+  ],
+  "phpVersion": "8.2",
+  "config": {
+    "WP_DEBUG": true,
+    "WP_DEBUG_LOG": true,
+    "SCRIPT_DEBUG": true
+  },
+  "lifecycleScripts": {
+    "afterStart": "wp-env run cli wp plugin install query-monitor --activate"
+  },
+  "env": {
+    "tests": {
+      "phpVersion": "8.4",
+      "core": "WordPress/WordPress#trunk"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `.wp-env.json` to standardise local development environment across all VIP-maintained plugins.

## Changes

  - Add `.wp-env.json` configuration file
  - PHP version set to plugin minimum (varies by plugin)
  - WordPress set to latest production release (auto-updates)
  - Query Monitor auto-installed via lifecycle script
  - Debug constants enabled (WP_DEBUG, WP_DEBUG_LOG, SCRIPT_DEBUG)
  - Test environment configured with PHP 8.4 + WordPress trunk

## Benefits

  - Simple `wp-env start` to get started
  - Automatic Query Monitor installation
  - Test against bleeding-edge PHP/WP with `wp-env start --env=tests`
  - Replaces other local dev-env with code-based configuration

## Testing

~~~bash
npm g -i @wordpress/env
wp-env start
# Visit http://localhost:8888
# Query Monitor and this plugin should be active
~~~