### PR TITLE
Increase minimum supported WordPress version to 6.6

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -10,7 +10,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding this minimum_supported_wp_version:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wpcs-0140 -->
-	<config name="minimum_supported_wp_version" value="4.4.2"/>
+	<config name="minimum_supported_wp_version" value="6.4"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -10,7 +10,7 @@
 	<rule ref="WordPress-Docs"/>
 	<!-- For help in understanding this minimum_supported_wp_version:
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties#setting-minimum-supported-wp-version-for-all-sniffs-in-one-go-wpcs-0140 -->
-	<config name="minimum_supported_wp_version" value="6.4"/>
+	<config name="minimum_supported_wp_version" value="6.6"/>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Contributors:** humanmade, djpaul, garyj  
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
-**Requires at least:** 4.4.2  
+**Requires at least:** 6.4  
 **Tested up to:** 6.8  
 **Stable tag:** 1.0.5  
 **License:** GPLv2 or later  

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Contributors:** humanmade, djpaul, garyj  
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
-**Requires at least:** 6.4  
+**Requires at least:** 6.6  
 **Tested up to:** 6.8  
 **Stable tag:** 1.0.5  
 **License:** GPLv2 or later  

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -11,7 +11,7 @@
  * Plugin Name:       BuddyPress VIP Go
  * Description:       Makes BuddyPress' media work with WordPress VIP's hosting.
  * Version:           1.0.5
- * Requires at least: 6.4
+ * Requires at least: 6.6
  * Requires PHP:      8.2
  * Author:            Human Made, WordPress VIP
  * Text Domain:       buddypress-vip-go

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -11,7 +11,7 @@
  * Plugin Name:       BuddyPress VIP Go
  * Description:       Makes BuddyPress' media work with WordPress VIP's hosting.
  * Version:           1.0.5
- * Requires at least: 4.4.2
+ * Requires at least: 6.4
  * Requires PHP:      8.2
  * Author:            Human Made, WordPress VIP
  * Text Domain:       buddypress-vip-go


### PR DESCRIPTION
## Summary

Bumps the minimum required WordPress version to 6.6.

## Why

WordPress 6.6 provides a more modern baseline, with 83% of WordPress sites running 6.6 or later.

## Testing

No functional changes - this only updates metadata and code standards configuration.