### PR TITLE
fix: Support BuddyPress 6.0+ avatar filter rename

### DIFF
--- a/files.php
+++ b/files.php
@@ -371,7 +371,9 @@ function vipbp_handle_avatar_upload( $_, $file, $upload_dir_filter ) {
 
 
 	// Set placeholder meta for image crop.
-	if ( 'xprofile_avatar_upload_dir' === $upload_dir_filter ) {
+	// Check for both old (pre-BP 6.0) and new filter names for backwards compatibility.
+	$user_avatar_filters = array( 'xprofile_avatar_upload_dir', 'bp_members_avatar_upload_dir' );
+	if ( in_array( $upload_dir_filter, $user_avatar_filters, true ) ) {
 		update_user_meta(
 			(int) $object_id,
 			"vipbp-{$avatar_type}",
@@ -474,7 +476,9 @@ function vipbp_handle_avatar_capture( $_, $data, $item_id ) {
 	);
 
 	// Upload the avatar.
-	bp_core_avatar_handle_upload( $file, 'xprofile_avatar_upload_dir' );
+	// Use new filter name (BP 6.0+) if available, otherwise fall back to old name.
+	$avatar_upload_filter = function_exists( 'bp_members_avatar_upload_dir' ) ? 'bp_members_avatar_upload_dir' : 'xprofile_avatar_upload_dir';
+	bp_core_avatar_handle_upload( $file, $avatar_upload_filter );
 
 	// And crop it.
 	bp_core_avatar_handle_crop(


### PR DESCRIPTION
## Summary

Fixes #30.

BuddyPress 6.0 (released 2020) moved avatar management from the xProfile component to the Members component, renaming the `xprofile_avatar_upload_dir` filter to `bp_members_avatar_upload_dir`.

This caused avatar uploads to silently fail on BP 6.0+ because the condition checking for the filter name never matched, so `update_user_meta()` was never called.

## Changes

- Check for both old (`xprofile_avatar_upload_dir`) and new (`bp_members_avatar_upload_dir`) filter names when saving user avatar meta
- Use `function_exists()` to determine which filter name to pass to `bp_core_avatar_handle_upload()` for webcam captures

## Backwards Compatibility

Maintains compatibility with BuddyPress < 6.0 by checking for both filter names.

## Test Plan

- [x] Test avatar upload on BuddyPress 14.4.0
- [x] Verify `vipbp-avatars` user meta contains `url` and `ui_width` fields after upload
- [ ] Test webcam avatar capture if available
- [ ] Optionally test on older BuddyPress to confirm backwards compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)