### PR TITLE
docs: Add note about plugin activation order

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Deleting files is handled by deleting the meta data, and then calling `wp_delete
 ## Installation
 
 1. Upload the `buddypress-vip-go` folder to the `/wp-content/plugins/` directory
-2. Activate the plugin through the 'Plugins' menu in WordPress
-3. No additional configuration is required
+2. **Activate this plugin before activating BuddyPress** to avoid fatal errors during BuddyPress initialisation
+3. Activate BuddyPress
+4. No additional configuration is required
 
 ## Changelog
 


### PR DESCRIPTION
## Summary

Adds a note to the README clarifying that BuddyPress-VIP-Go should be activated **before** BuddyPress to avoid fatal errors during BuddyPress initialisation on VIP.

## Context

Discovered during testing that activating BuddyPress first can cause fatal errors because BuddyPress tries to access file system paths that don't work on VIP without this plugin's filters in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)