### PR TITLE
fix: Disable avatar history to prevent filesystem access

### DIFF
--- a/files.php
+++ b/files.php
@@ -11,6 +11,9 @@ defined( 'ABSPATH' ) || exit;
 add_action(
 	'bp_init',
 	function () {
+		// Disable avatar history feature (BP 10.0+) as it requires filesystem directory listing.
+		add_filter( 'bp_disable_avatar_history', '__return_true' );
+
 		// Tweaks for fetching avatars and cover images -- bp_core_fetch_avatar() and bp_attachments_get_attachment().
 		add_filter( 'bp_core_avatar_folder_dir', '__return_empty_string' );
 		add_filter( 'bp_core_fetch_avatar_no_grav', '__return_true' );


### PR DESCRIPTION
## Summary

Fixes #29.

BuddyPress 10.0+ introduced avatar history/recycling which requires directory listing via `FilesystemIterator`. This fails on VIP as the `vip://` stream wrapper doesn't support directory iteration, causing a fatal error when accessing the change-avatar page.

## Changes

Disable avatar history via the `bp_disable_avatar_history` filter. This prevents the `FilesystemIterator` error but disables the "Recycle" feature in the avatar UI.

## Upstream

Requested a pre-filter in BuddyPress to support custom storage backends in the future:
https://buddypress.trac.wordpress.org/ticket/9311

## Test Plan

- [x] Verify change-avatar page loads without `FilesystemIterator` error on VIP
- [x] Verify avatar upload still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)