### PR TITLE
Move avatar folder dir filter outside bp_init callback

### DIFF
--- a/files.php
+++ b/files.php
@@ -11,11 +11,14 @@ defined( 'ABSPATH' ) || exit;
 // Disable avatar history feature (BP 10.0+) as it requires filesystem directory listing.
 add_filter( 'bp_disable_avatar_history', '__return_true' );
 
+// Prevent BuddyPress from scanning the filesystem for avatar files.
+// This must be added early (before bp_init priority 8 where bp_setup_title runs).
+add_filter( 'bp_core_avatar_folder_dir', '__return_empty_string' );
+
 add_action(
 	'bp_init',
 	function () {
 		// Tweaks for fetching avatars and cover images -- bp_core_fetch_avatar() and bp_attachments_get_attachment().
-		add_filter( 'bp_core_avatar_folder_dir', '__return_empty_string' );
 		add_filter( 'bp_core_fetch_avatar_no_grav', '__return_true' );
 		add_filter( 'bp_core_default_avatar_user', 'vipbp_filter_user_avatar_urls', 10, 2 );
 		add_filter( 'bp_core_default_avatar_group', 'vipbp_filter_group_avatar_urls', 10, 2 );


### PR DESCRIPTION
## Summary
- Moves the `bp_core_avatar_folder_dir` filter outside the `bp_init` callback so it runs immediately when the plugin loads

## Problem
The filter was being added inside a `bp_init` callback at default priority (10), but `bp_setup_title` runs at priority 8 on `bp_init` and calls `bp_core_fetch_avatar()`. This caused `opendir()` warnings on VIP's filesystem because the filter wasn't in place yet when the avatar lookup happened.

## Solution
By moving the filter outside the callback, it's available immediately when the plugin loads, before any `bp_init` actions fire.

## Test plan
- [ ] Deploy to a VIP environment
- [ ] Check logs for `opendir()` warnings on `avatars/0` path
- [ ] Verify avatar display still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)