### PR TITLE
Release 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.7] - 2025-12-16
+
+### Fixed
+
+- Move avatar folder dir filter outside bp_init callback to prevent opendir() warnings by @GaryJones in <https://github.com/Automattic/BuddyPress-VIP-Go/pull/37>
+
 ## [1.0.6] - 2025-12-16
 
 ### Fixed
@@ -72,6 +78,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of BuddyPress for VIP Go
 
+[1.0.7]: https://github.com/automattic/buddypress-vip-go/compare/1.0.6...1.0.7
 [1.0.6]: https://github.com/automattic/buddypress-vip-go/compare/1.0.5...1.0.6
 [1.0.5]: https://github.com/automattic/buddypress-vip-go/compare/1.0.4...1.0.5
 [1.0.4]: https://github.com/automattic/buddypress-vip-go/compare/1.0.3...1.0.4

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
 **Requires at least:** 6.6  
 **Tested up to:** 6.8  
-**Stable tag:** 1.0.6  
+**Stable tag:** 1.0.7  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       BuddyPress VIP Go
  * Description:       Makes BuddyPress' media work with WordPress VIP's hosting.
- * Version:           1.0.6
+ * Version:           1.0.7
  * Requires at least: 6.6
  * Requires PHP:      8.2
  * Author:            Human Made, WordPress VIP

--- a/files.php
+++ b/files.php
@@ -11,11 +11,14 @@ defined( 'ABSPATH' ) || exit;
 // Disable avatar history feature (BP 10.0+) as it requires filesystem directory listing.
 add_filter( 'bp_disable_avatar_history', '__return_true' );
 
+// Prevent BuddyPress from scanning the filesystem for avatar files.
+// This must be added early (before bp_init priority 8 where bp_setup_title runs).
+add_filter( 'bp_core_avatar_folder_dir', '__return_empty_string' );
+
 add_action(
 	'bp_init',
 	function () {
 		// Tweaks for fetching avatars and cover images -- bp_core_fetch_avatar() and bp_attachments_get_attachment().
-		add_filter( 'bp_core_avatar_folder_dir', '__return_empty_string' );
 		add_filter( 'bp_core_fetch_avatar_no_grav', '__return_true' );
 		add_filter( 'bp_core_default_avatar_user', 'vipbp_filter_user_avatar_urls', 10, 2 );
 		add_filter( 'bp_core_default_avatar_group', 'vipbp_filter_group_avatar_urls', 10, 2 );


### PR DESCRIPTION
## Release 1.0.7

### Fixed

- Move avatar folder dir filter outside bp_init callback to prevent opendir() warnings by @GaryJones in #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)