### PR TITLE
Release 1.0.8

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,25 @@
+# BuddyPress VIP Go
+
+BuddyPress integration and compatibility layer for WordPress VIP Go platform.
+
+## Plugin Details
+
+| Property | Value |
+|----------|-------|
+| **Main file** | `buddypress-vip-go.php` |
+| **Text domain** | `buddypress-vip-go` |
+| **Function prefix** | `bp_vip_go_` |
+| **Namespace** | `Automattic\BuddyPressVIPGo` |
+| **Source directory** | Root level (no subdirectory) |
+| **Version** | 1.0.8 |
+| **Requires PHP** | 8.2+ |
+
+## Notes
+
+- Tier 3 plugin (needs work per PLUGIN_AUDIT.md)
+- Missing tests infrastructure
+- Missing CI workflows
+
+## Standards
+
+Follow the standards documented in `~/code/plugin-standards/`.

--- a/.distignore
+++ b/.distignore
@@ -1,4 +1,5 @@
 # Directories
+/.claude/
 /.git/
 /.github/
 /bin/

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 # If you develop for CAP using Composer, use `--prefer-source`.
 # https://blog.madewithlove.be/post/gitattributes/
 
+/.claude/         export-ignore
 /.github/         export-ignore
 /tests/           export-ignore
 /.distignore      export-ignore

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -23,6 +23,11 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: "Basic CS and QA checks"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -40,8 +40,8 @@ jobs:
           # Check lowest supported WP version, with the lowest supported PHP.
           - wordpress: '6.6'
             php: '8.2'
-          # Check latest WP with the highest supported PHP.
-          - wordpress: 'latest'
+          # Check latest WP with the latest PHP.
+          - wordpress: 'master'
             php: 'latest'
       fail-fast: false
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup wp-env
         run: wp-env start
         env:
-          WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress == 'latest' && 'master' || matrix.wordpress }}
+          WP_ENV_CORE: WordPress/WordPress#${{ matrix.wordpress }}
 
       - name: Run integration tests (single site)
         run: composer test:integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.8] - 2025-01-12
+
+### Fixed
+
+- Fix default group avatar uploads in BuddyBoss by storing metadata in option instead of group meta when item_id=0 by @GaryJones in <https://github.com/Automattic/BuddyPress-VIP-Go/pull/41>
+- Fall back to default group avatar for groups without specific avatars by @GaryJones in <https://github.com/Automattic/BuddyPress-VIP-Go/pull/41>
+
 ## [1.0.7] - 2025-12-16
 
 ### Fixed
@@ -78,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of BuddyPress for VIP Go
 
+[1.0.8]: https://github.com/automattic/buddypress-vip-go/compare/1.0.7...1.0.8
 [1.0.7]: https://github.com/automattic/buddypress-vip-go/compare/1.0.6...1.0.7
 [1.0.6]: https://github.com/automattic/buddypress-vip-go/compare/1.0.5...1.0.6
 [1.0.5]: https://github.com/automattic/buddypress-vip-go/compare/1.0.4...1.0.5

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **Contributors:** humanmade, djpaul, garyj  
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
 **Requires at least:** 6.6  
-**Tested up to:** 6.8  
+**Tested up to:** 6.9  
 **Stable tag:** 1.0.7  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
 **Requires at least:** 6.6  
 **Tested up to:** 6.9  
-**Stable tag:** 1.0.7  
+**Stable tag:** 1.0.8  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       BuddyPress VIP Go
  * Description:       Makes BuddyPress' media work with WordPress VIP's hosting.
- * Version:           1.0.7
+ * Version:           1.0.8
  * Requires at least: 6.6
  * Requires PHP:      8.2
  * Author:            Human Made, WordPress VIP

--- a/files.php
+++ b/files.php
@@ -112,6 +112,12 @@ function vipbp_filter_group_avatar_urls( $_, $params ) {
 	} else {
 		// phpcs:ignore Universal.Operators.DisallowShortTernary.Found
 		$meta = groups_get_groupmeta( $params['item_id'], 'vipbp-group-avatars', true ) ?: array();
+
+		// If no specific avatar for this group, fall back to default group avatar.
+		if ( empty( $meta ) || empty( $meta['url'] ) ) {
+			// phpcs:ignore Universal.Operators.DisallowShortTernary.Found
+			$meta = bp_get_option( 'vipbp-default-group-avatar', array() ) ?: array();
+		}
 	}
 
 	$retval = vipbp_filter_avatar_urls( $params, $meta );

--- a/languages/buddypress-vip-go.pot
+++ b/languages/buddypress-vip-go.pot
@@ -1,0 +1,49 @@
+# Copyright (C) 2026 Human Made, WordPress VIP
+# This file is distributed under the GPL v2 or later.
+msgid ""
+msgstr ""
+"Project-Id-Version: BuddyPress VIP Go 1.0.8\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/buddypress-vip-go\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-01-12T20:12:08+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: buddypress-vip-go\n"
+
+#. Plugin Name of the plugin
+#: buddypress-vip-go.php
+msgid "BuddyPress VIP Go"
+msgstr ""
+
+#. Description of the plugin
+#: buddypress-vip-go.php
+msgid "Makes BuddyPress' media work with WordPress VIP's hosting."
+msgstr ""
+
+#. Author of the plugin
+#: buddypress-vip-go.php
+msgid "Human Made, WordPress VIP"
+msgstr ""
+
+#. translators: %s: Error message returned during the upload process.
+#: files.php:367
+#: files.php:493
+#, php-format
+msgid "Upload failed! Error was: %s"
+msgstr ""
+
+#. translators: 1: Avatar width. 2: Avatar height.
+#: files.php:445
+#, php-format
+msgid "You have selected an image that is smaller than recommended. For best results, upload a picture larger than %1$d x %2$d pixels."
+msgstr ""
+
+#. translators: %s: Error message returned during the upload process.
+#: files.php:596
+#, php-format
+msgid "Upload Failed! Error was: %s"
+msgstr ""


### PR DESCRIPTION
## Summary
Release 1.0.8 with default group avatar fixes.

### Fixed
- Fix default group avatar uploads in BuddyBoss by storing metadata in option instead of group meta when item_id=0
- Fall back to default group avatar for groups without specific avatars

### Chores
- Add .claude directory and workflow improvements
- Version bump and changelog

## Supersedes
Supersedes #41 (fix branch PR)

## Test plan
- [x] Tested on community.wpvip.com production

🤖 Generated with [Claude Code](https://claude.com/claude-code)