### PR TITLE
Release 1.0.9

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ BuddyPress integration and compatibility layer for WordPress VIP Go platform.
 | **Function prefix** | `bp_vip_go_` |
 | **Namespace** | `Automattic\BuddyPressVIPGo` |
 | **Source directory** | Root level (no subdirectory) |
-| **Version** | 1.0.8 |
+| **Version** | 1.0.9 |
 | **Requires PHP** | 8.2+ |
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.9] - 2025-01-21
+
+### Fixed
+
+- Redirect chunked video uploads to local temp directory to fix "Failed to create lock file" error by @GaryJones in <https://github.com/Automattic/BuddyPress-VIP-Go/pull/44>
+
 ## [1.0.8] - 2025-01-12
 
 ### Fixed
@@ -85,6 +91,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of BuddyPress for VIP Go
 
+[1.0.9]: https://github.com/automattic/buddypress-vip-go/compare/1.0.8...1.0.9
 [1.0.8]: https://github.com/automattic/buddypress-vip-go/compare/1.0.7...1.0.8
 [1.0.7]: https://github.com/automattic/buddypress-vip-go/compare/1.0.6...1.0.7
 [1.0.6]: https://github.com/automattic/buddypress-vip-go/compare/1.0.5...1.0.6

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
 **Requires at least:** 6.6  
 **Tested up to:** 6.9  
-**Stable tag:** 1.0.8  
+**Stable tag:** 1.0.9  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       BuddyPress VIP Go
  * Description:       Makes BuddyPress' media work with WordPress VIP's hosting.
- * Version:           1.0.8
+ * Version:           1.0.9
  * Requires at least: 6.6
  * Requires PHP:      8.2
  * Author:            Human Made, WordPress VIP

--- a/files.php
+++ b/files.php
@@ -40,6 +40,7 @@ add_action(
 
 		// Tweaks for uploading videos into groups.
 		add_filter( 'bp_core_pre_remove_temp_directory', 'vipbp_override_remove_temp_directory', 10, 3 );
+		add_filter( 'bfu_temp_dir', 'vipbp_filter_chunked_upload_temp_dir' );
 
 		// Tweaks for flushing the cache after moving a video.
 		add_action( 'bp_video_after_save', 'vipbp_flush_cache_after_video_move', 99 );
@@ -898,4 +899,22 @@ function vipbp_override_remove_temp_directory( $override, $directory, $image_nam
  */
 function vipbp_flush_cache_after_video_move() {
 	bp_core_reset_incrementor( 'bp_media' );
+}
+
+/**
+ * Redirect BuddyBoss chunked video uploads to a local temp directory.
+ *
+ * By default, BuddyBoss uses wp_upload_dir() for chunked uploads, which on VIP
+ * points to the File Hosting Service (FHS). FHS doesn't support file locking
+ * operations (flock) needed for the upload process, causing "Failed to create
+ * lock file" errors.
+ *
+ * This filter redirects chunked uploads to the server's local temp directory
+ * where file locking works correctly. The final assembled file is still moved
+ * to the proper FHS location after upload completes.
+ *
+ * @return string Path to the local temp directory for chunked uploads.
+ */
+function vipbp_filter_chunked_upload_temp_dir() {
+	return get_temp_dir() . 'bb-large-upload';
 }

--- a/languages/buddypress-vip-go.pot
+++ b/languages/buddypress-vip-go.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: BuddyPress VIP Go 1.0.8\n"
+"Project-Id-Version: BuddyPress VIP Go 1.0.9\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/buddypress-vip-go\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-01-12T20:12:08+00:00\n"
+"POT-Creation-Date: 2026-01-21T14:14:13+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: buddypress-vip-go\n"
@@ -30,20 +30,20 @@ msgid "Human Made, WordPress VIP"
 msgstr ""
 
 #. translators: %s: Error message returned during the upload process.
-#: files.php:367
-#: files.php:493
+#: files.php:368
+#: files.php:494
 #, php-format
 msgid "Upload failed! Error was: %s"
 msgstr ""
 
 #. translators: 1: Avatar width. 2: Avatar height.
-#: files.php:445
+#: files.php:446
 #, php-format
 msgid "You have selected an image that is smaller than recommended. For best results, upload a picture larger than %1$d x %2$d pixels."
 msgstr ""
 
 #. translators: %s: Error message returned during the upload process.
-#: files.php:596
+#: files.php:597
 #, php-format
 msgid "Upload Failed! Error was: %s"
 msgstr ""


### PR DESCRIPTION
## Summary
Release 1.0.9 with chunked video upload fix.

### Fixed
- Redirect chunked video uploads to local temp directory to fix "Failed to create lock file" error

## Test plan
- [x] Tested on community.wpvip.com with 120MB MP4 video upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)