### PR TITLE
Release 1.0.10

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ BuddyPress integration and compatibility layer for WordPress VIP Go platform.
 | **Function prefix** | `bp_vip_go_` |
 | **Namespace** | `Automattic\BuddyPressVIPGo` |
 | **Source directory** | Root level (no subdirectory) |
-| **Version** | 1.0.9 |
+| **Version** | 1.0.10 |
 | **Requires PHP** | 8.2+ |
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.10] - 2025-01-23
+
+### Fixed
+
+- Filter BuddyBoss default group avatar to prevent opendir error by @GaryJones in <https://github.com/Automattic/BuddyPress-VIP-Go/pull/47>
+
 ## [1.0.9] - 2025-01-21
 
 ### Fixed
@@ -91,6 +97,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of BuddyPress for VIP Go
 
+[1.0.10]: https://github.com/automattic/buddypress-vip-go/compare/1.0.9...1.0.10
 [1.0.9]: https://github.com/automattic/buddypress-vip-go/compare/1.0.8...1.0.9
 [1.0.8]: https://github.com/automattic/buddypress-vip-go/compare/1.0.7...1.0.8
 [1.0.7]: https://github.com/automattic/buddypress-vip-go/compare/1.0.6...1.0.7

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
 **Requires at least:** 6.6  
 **Tested up to:** 6.9  
-**Stable tag:** 1.0.9  
+**Stable tag:** 1.0.10  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       BuddyPress VIP Go
  * Description:       Makes BuddyPress' media work with WordPress VIP's hosting.
- * Version:           1.0.9
+ * Version:           1.0.10
  * Requires at least: 6.6
  * Requires PHP:      8.2
  * Author:            Human Made, WordPress VIP

--- a/languages/buddypress-vip-go.pot
+++ b/languages/buddypress-vip-go.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: BuddyPress VIP Go 1.0.9\n"
+"Project-Id-Version: BuddyPress VIP Go 1.0.10\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/buddypress-vip-go\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-01-21T14:14:13+00:00\n"
+"POT-Creation-Date: 2026-01-23T15:19:22+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: buddypress-vip-go\n"
@@ -30,20 +30,20 @@ msgid "Human Made, WordPress VIP"
 msgstr ""
 
 #. translators: %s: Error message returned during the upload process.
-#: files.php:368
-#: files.php:494
+#: files.php:372
+#: files.php:498
 #, php-format
 msgid "Upload failed! Error was: %s"
 msgstr ""
 
 #. translators: 1: Avatar width. 2: Avatar height.
-#: files.php:446
+#: files.php:450
 #, php-format
 msgid "You have selected an image that is smaller than recommended. For best results, upload a picture larger than %1$d x %2$d pixels."
 msgstr ""
 
 #. translators: %s: Error message returned during the upload process.
-#: files.php:597
+#: files.php:601
 #, php-format
 msgid "Upload Failed! Error was: %s"
 msgstr ""


### PR DESCRIPTION
## Summary
Release 1.0.10 with BuddyBoss default group avatar opendir fix.

### Fixed
- Filter BuddyBoss default group avatar to prevent opendir error

## Test plan
- [x] Tested on community.wpvip.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)