### PR TITLE
Fix: Register opendir filters before bp_init priority 8

### DIFF
--- a/files.php
+++ b/files.php
@@ -15,6 +15,11 @@ add_filter( 'bp_disable_avatar_history', '__return_true' );
 // This must be added early (before bp_init priority 8 where bp_setup_title runs).
 add_filter( 'bp_core_avatar_folder_dir', '__return_empty_string' );
 
+// Prevent BuddyBoss from calling bb_get_default_custom_avatar() which uses opendir().
+// This must be added early (before bp_init priority 8 where bp_setup_title runs).
+add_filter( 'option_bp-default-custom-group-avatar', 'vipbp_filter_default_group_avatar_option' );
+add_filter( 'bb_get_default_custom_upload_group_avatar', 'vipbp_filter_bb_default_group_avatar' );
+
 add_action(
 	'bp_init',
 	function () {
@@ -44,10 +49,6 @@ add_action(
 
 		// Tweaks for flushing the cache after moving a video.
 		add_action( 'bp_video_after_save', 'vipbp_flush_cache_after_video_move', 99 );
-
-		// Tweaks for BuddyBoss default group avatar to prevent opendir() errors.
-		add_filter( 'option_bp-default-custom-group-avatar', 'vipbp_filter_default_group_avatar_option' );
-		add_filter( 'bb_get_default_custom_upload_group_avatar', 'vipbp_filter_bb_default_group_avatar' );
 	}
 );
 


### PR DESCRIPTION
## Summary
- Move BuddyBoss default group avatar filters outside the `bp_init` callback
- Filters now run early enough (before `bp_setup_title` at priority 8)
- Fixes opendir() errors that were occurring on every request

## Background
The filters added in 1.0.10 were registered inside `bp_init` at default priority 10, but `bp_setup_title` runs at priority 8 and triggers the opendir() call. Moving the filters outside the callback ensures they're registered before any BuddyPress initialization.

## Test plan
- [ ] Verify no opendir errors in VIP logs after deployment
- [ ] Verify default group avatar still displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)