### PR TITLE
fix: use https:// instead of protocol-relative URL for Gravatar

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ BuddyPress integration and compatibility layer for WordPress VIP Go platform.
 | **Function prefix** | `bp_vip_go_` |
 | **Namespace** | `Automattic\BuddyPressVIPGo` |
 | **Source directory** | Root level (no subdirectory) |
-| **Version** | 1.0.10 |
+| **Version** | 1.0.11 |
 | **Requires PHP** | 8.2+ |
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.11] - 2026-01-26
+
+### Fixed
+
+- Register opendir filters before bp_init priority 8 to fix timing issue by @GaryJones in <https://github.com/Automattic/BuddyPress-VIP-Go/pull/51>
+
 ## [1.0.10] - 2025-01-23
 
 ### Fixed
@@ -97,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of BuddyPress for VIP Go
 
+[1.0.11]: https://github.com/automattic/buddypress-vip-go/compare/1.0.10...1.0.11
 [1.0.10]: https://github.com/automattic/buddypress-vip-go/compare/1.0.9...1.0.10
 [1.0.9]: https://github.com/automattic/buddypress-vip-go/compare/1.0.8...1.0.9
 [1.0.8]: https://github.com/automattic/buddypress-vip-go/compare/1.0.7...1.0.8

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
 **Requires at least:** 6.6  
 **Tested up to:** 6.9  
-**Stable tag:** 1.0.10  
+**Stable tag:** 1.0.11  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       BuddyPress VIP Go
  * Description:       Makes BuddyPress' media work with WordPress VIP's hosting.
- * Version:           1.0.10
+ * Version:           1.0.11
  * Requires at least: 6.6
  * Requires PHP:      8.2
  * Author:            Human Made, WordPress VIP

--- a/files.php
+++ b/files.php
@@ -179,7 +179,7 @@ function vipbp_filter_avatar_urls( $params, $meta ) {
 		}
 
 		$params['email'] = apply_filters( 'bp_core_gravatar_email', $params['email'], $params['item_id'], $params['object'] );
-		$gravatar        = apply_filters( 'bp_gravatar_url', '//www.gravatar.com/avatar/' );
+		$gravatar        = apply_filters( 'bp_gravatar_url', 'https://www.gravatar.com/avatar/' );
 		$gravatar       .= md5( strtolower( $params['email'] ) );
 
 		$gravatar_args = array(

--- a/languages/buddypress-vip-go.pot
+++ b/languages/buddypress-vip-go.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: BuddyPress VIP Go 1.0.10\n"
+"Project-Id-Version: BuddyPress VIP Go 1.0.11\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/buddypress-vip-go\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-01-23T15:19:22+00:00\n"
+"POT-Creation-Date: 2026-01-26T16:58:52+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: buddypress-vip-go\n"
@@ -30,20 +30,20 @@ msgid "Human Made, WordPress VIP"
 msgstr ""
 
 #. translators: %s: Error message returned during the upload process.
-#: files.php:372
-#: files.php:498
+#: files.php:373
+#: files.php:499
 #, php-format
 msgid "Upload failed! Error was: %s"
 msgstr ""
 
 #. translators: 1: Avatar width. 2: Avatar height.
-#: files.php:450
+#: files.php:451
 #, php-format
 msgid "You have selected an image that is smaller than recommended. For best results, upload a picture larger than %1$d x %2$d pixels."
 msgstr ""
 
 #. translators: %s: Error message returned during the upload process.
-#: files.php:601
+#: files.php:602
 #, php-format
 msgid "Upload Failed! Error was: %s"
 msgstr ""


### PR DESCRIPTION
## Summary

- Changes Gravatar URL from protocol-relative (`//www.gravatar.com`) to absolute (`https://www.gravatar.com`)
- Fixes broken avatar images in BuddyBoss email notifications

## Context

When users without uploaded avatars receive email notifications from BuddyBoss, their Gravatar images were not displaying. Investigation revealed that the `vipbp_filter_avatar_urls()` function was using a protocol-relative URL (`//www.gravatar.com/avatar/`) for Gravatar.

Email clients don't handle protocol-relative URLs - they need absolute URLs with an explicit `https://` protocol to load external images.

BuddyBoss itself uses `https://www.gravatar.com/avatar/` throughout its codebase, so this brings our code in line with that pattern.

## Test plan

- [ ] Deploy to a test environment
- [ ] Trigger an email notification from a user who uses Gravatar (no uploaded avatar)
- [ ] Verify the avatar image appears correctly in the email

🤖 Generated with [Claude Code](https://claude.com/claude-code)