### PR TITLE
Release 1.0.12

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,7 @@ BuddyPress integration and compatibility layer for WordPress VIP Go platform.
 | **Function prefix** | `bp_vip_go_` |
 | **Namespace** | `Automattic\BuddyPressVIPGo` |
 | **Source directory** | Root level (no subdirectory) |
-| **Version** | 1.0.11 |
+| **Version** | 1.0.12 |
 | **Requires PHP** | 8.2+ |
 
 ## Notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.12] - 2026-01-27
+
+### Fixed
+
+- Use absolute https:// URL instead of protocol-relative URL for Gravatar to fix broken avatars in email notifications by @GaryJones in <https://github.com/Automattic/BuddyPress-VIP-Go/pull/54>
+
 ## [1.0.11] - 2026-01-26
 
 ### Fixed
@@ -103,6 +109,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of BuddyPress for VIP Go
 
+[1.0.12]: https://github.com/automattic/buddypress-vip-go/compare/1.0.11...1.0.12
 [1.0.11]: https://github.com/automattic/buddypress-vip-go/compare/1.0.10...1.0.11
 [1.0.10]: https://github.com/automattic/buddypress-vip-go/compare/1.0.9...1.0.10
 [1.0.9]: https://github.com/automattic/buddypress-vip-go/compare/1.0.8...1.0.9

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **Tags:** BuddyPress, BuddyBoss, WordPress VIP  
 **Requires at least:** 6.6  
 **Tested up to:** 6.9  
-**Stable tag:** 1.0.11  
+**Stable tag:** 1.0.12  
 **License:** GPLv2 or later  
 **License URI:** https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/buddypress-vip-go.php
+++ b/buddypress-vip-go.php
@@ -10,7 +10,7 @@
  * @wordpress-plugin
  * Plugin Name:       BuddyPress VIP Go
  * Description:       Makes BuddyPress' media work with WordPress VIP's hosting.
- * Version:           1.0.11
+ * Version:           1.0.12
  * Requires at least: 6.6
  * Requires PHP:      8.2
  * Author:            Human Made, WordPress VIP

--- a/files.php
+++ b/files.php
@@ -179,7 +179,7 @@ function vipbp_filter_avatar_urls( $params, $meta ) {
 		}
 
 		$params['email'] = apply_filters( 'bp_core_gravatar_email', $params['email'], $params['item_id'], $params['object'] );
-		$gravatar        = apply_filters( 'bp_gravatar_url', '//www.gravatar.com/avatar/' );
+		$gravatar        = apply_filters( 'bp_gravatar_url', 'https://www.gravatar.com/avatar/' );
 		$gravatar       .= md5( strtolower( $params['email'] ) );
 
 		$gravatar_args = array(

--- a/languages/buddypress-vip-go.pot
+++ b/languages/buddypress-vip-go.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: BuddyPress VIP Go 1.0.11\n"
+"Project-Id-Version: BuddyPress VIP Go 1.0.12\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/buddypress-vip-go\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
## Release 1.0.12

### Fixed

- Use absolute https:// URL instead of protocol-relative URL for Gravatar to fix broken avatars in email notifications (#54)

---

Merge to main and tag as `1.0.12`.