### PR TITLE
fix: register bfu_temp_dir filter before bp_init

### DIFF
--- a/files.php
+++ b/files.php
@@ -20,6 +20,10 @@ add_filter( 'bp_core_avatar_folder_dir', '__return_empty_string' );
 add_filter( 'option_bp-default-custom-group-avatar', 'vipbp_filter_default_group_avatar_option' );
 add_filter( 'bb_get_default_custom_upload_group_avatar', 'vipbp_filter_bb_default_group_avatar' );
 
+// Redirect chunked video uploads to local temp directory.
+// This must be added early because video upload AJAX runs before bp_init.
+add_filter( 'bfu_temp_dir', 'vipbp_filter_chunked_upload_temp_dir' );
+
 add_action(
 	'bp_init',
 	function () {
@@ -45,7 +49,6 @@ add_action(
 
 		// Tweaks for uploading videos into groups.
 		add_filter( 'bp_core_pre_remove_temp_directory', 'vipbp_override_remove_temp_directory', 10, 3 );
-		add_filter( 'bfu_temp_dir', 'vipbp_filter_chunked_upload_temp_dir' );
 
 		// Tweaks for flushing the cache after moving a video.
 		add_action( 'bp_video_after_save', 'vipbp_flush_cache_after_video_move', 99 );


### PR DESCRIPTION
## Summary
- Move `bfu_temp_dir` filter registration from inside `bp_init` callback to early file load
- Video upload AJAX handlers run before `bp_init` fires, so the filter wasn't being applied
- Users were getting "Video is being processed. Please wait." errors after uploads reached 100%

## Problem
The `bfu_temp_dir` filter redirects chunked video uploads to the local temp directory (needed because VIP FHS doesn't support `flock()` operations). When registered inside the `bp_init` callback, it loaded too late for the video upload AJAX handler which runs on `admin_init`.

## Solution
Move the filter registration to the early filter block at the top of files.php, alongside other filesystem-related filters that also need to load before `bp_init`.

## Test plan
- [ ] Upload a large video (100MB+) to a group on VIP
- [ ] Verify upload completes successfully without "Video is being processed" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)